### PR TITLE
Fix iOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ npm install
 npm run build
 cd ios/App
 pod install
+cd ../..
 npx cap run ios
 ```
   ou
@@ -88,6 +89,7 @@ bun install
 bun run build
 cd ios/App
 pod install
+cd ../..
 bunx cap run ios
 ```
 

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -10,5 +10,8 @@
 		"Keyboard": {
 			"resize": "none"
 		}
+	},
+	"ios": {
+		"scheme": "GiraPlus"
 	}
 }

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -23,7 +23,7 @@ def capacitor_pods
   pod 'CapacitorPluginSafeArea', :path => '../../node_modules/capacitor-plugin-safe-area'
 end
 
-target 'App' do
+target 'GiraPlus' do
   capacitor_pods
   # Add your Pods here
 end


### PR DESCRIPTION
iOS build was failing due to a refactoring of the App's name in the Xcode schema from the default Ionic one, causing a [well documented error](https://github.com/ionic-team/capacitor/issues/4166). This PR fixes it by changing the `capacitor.config.json` and `Podfile` files to match the new internal name. Also added a missing step to the compilation instructions in the `README.md` file to clarify that the last command must be run from the project's root directory.