### PR TITLE
Fix podfile target name

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -23,7 +23,7 @@ def capacitor_pods
   pod 'CapacitorPluginSafeArea', :path => '../../node_modules/capacitor-plugin-safe-area'
 end
 
-target 'App' do
+target 'GiraPlus' do
   capacitor_pods
   # Add your Pods here
 end


### PR DESCRIPTION
Changes default target name on Podfile to be the app's actual target name (GiraPlus).