### PR TITLE
update endpoints hostname

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,8 @@
 export const LOCK_DISTANCE_m = 35;
 export const MIN_TRAVEL_DISTANCE_m = 20;
 
-export const GIRA_AUTH_URL = 'https://egira-proxy-arqetk5clq-ew.a.run.app/auth';
-export const GIRA_API_URL = 'https://egira-proxy-arqetk5clq-ew.a.run.app/api';
-export const GIRA_WS_URL = 'wss://egira-proxy-arqetk5clq-ew.a.run.app/ws';
+export const GIRA_AUTH_URL = 'https://c2g091p01.emel.pt/auth';
+export const GIRA_API_URL = 'https://c2g091p01.emel.pt/api';
+export const GIRA_WS_URL = 'wss://c2g091p01.emel.pt/ws';
 
 export const FIREBASE_TOKEN_URL = 'https://gira.rodlabs.dev/firebase-token';


### PR DESCRIPTION
Old one is now disabled, sigh

Not sure whether new auth is required, your endpoint currently returns stale token